### PR TITLE
Correções de código

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ Lançado sob MIT, e copyright 2014, [@mdo](http://twitter.com/mdo/).
 Fortemente inspirado por [Idiomatic CSS](https://github.com/necolas/idiomatic-css) e [GitHub Styleguide](http://github.com/styleguide).
 
 ### Traduções
-<<<<<<< HEAD
 
 [Portuguese](http://diegoeis.github.io/code-guide/) - Translated by [Diego Eis](http://tableless.com.br/)
 [Spanish](http://adrianayala.mx/code-guide/es/) - Translated by [Adrian Ayala](http://adrianayala.mx/)

--- a/index.html
+++ b/index.html
@@ -291,6 +291,7 @@ layout: default
     <h3>Comentários</h3>
     <p>Código é escrito e mantido por pessoas. Certifique-se de que o código é descritivo, bem comentado e amigável para os outros. Grandes pedaços de comentários devem ter contexto e não devem apenas reiterar um nome de classe ou componente.</p>
     <p>Certifique-se de escrever em sentenças completas ou grandes comentários e frases sucintas para notas gerais.</p>
+  </div>
   <div class="col">
     {% highlight css %}{% include css/comments.css %}{% endhighlight %}
   </div>

--- a/pt-br.html
+++ b/pt-br.html
@@ -1,5 +1,6 @@
 <script>
-if (window.location.href.indexOf('http://diegoeis.github.io/code-guide/pt-br.html') === 0) {
+if ((window.location.href.indexOf('http://diegoeis.github.io/code-guide/pt-br.html') === 0)
+    || (window.location.href.indexOf('http://diegoeis.github.io/code-guide/pt-br') === 0)){
   window.location.href = 'http://diegoeis.github.io/code-guide/';
 }
 </script>


### PR DESCRIPTION
Correções:

1 - A página traduzida na seção "Legível para humanos" estava faltando o fechamento de uma div.
2 - O README.md estava "bugado", talvez algum conflito de git ou algo do tipo.
3 - O script para redirecionamento não estava funcionando para quando o endereço "/pt-br" fosse sem .html no final.
